### PR TITLE
Fix persona command registry paths for --all flag

### DIFF
--- a/src/aria_esi/commands/persona.py
+++ b/src/aria_esi/commands/persona.py
@@ -351,11 +351,11 @@ def cmd_persona_context(args: argparse.Namespace) -> dict:
 
     if getattr(args, "all", False):
         # Process all pilots from registry
-        registry_path = base_path / "pilots" / "_registry.json"
+        registry_path = base_path / "userdata" / "pilots" / "_registry.json"
         if registry_path.exists():
             registry = json.loads(registry_path.read_text())
             for pilot in registry.get("pilots", []):
-                pilot_dir = base_path / "pilots" / pilot["directory"]
+                pilot_dir = base_path / "userdata" / "pilots" / pilot["directory"]
                 if pilot_dir.exists():
                     pilots_to_process.append(
                         {
@@ -959,11 +959,11 @@ def cmd_validate_overlays(args: argparse.Namespace) -> dict:
 
     if getattr(args, "all", False):
         # Validate all pilots from registry
-        registry_path = base_path / "pilots" / "_registry.json"
+        registry_path = base_path / "userdata" / "pilots" / "_registry.json"
         if registry_path.exists():
             registry = json.loads(registry_path.read_text())
             for pilot in registry.get("pilots", []):
-                pilot_dir = base_path / "pilots" / pilot["directory"]
+                pilot_dir = base_path / "userdata" / "pilots" / pilot["directory"]
                 if pilot_dir.exists():
                     pilots_to_validate.append(
                         {

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -426,7 +426,7 @@ class TestCmdPersonaContext:
         from aria_esi.commands.persona import cmd_persona_context
 
         # Create pilot structure
-        pilot_dir = tmp_path / "pilots" / "123_test"
+        pilot_dir = tmp_path / "userdata" / "pilots" / "123_test"
         pilot_dir.mkdir(parents=True)
 
         profile = pilot_dir / "profile.md"
@@ -459,7 +459,7 @@ class TestCmdValidateOverlays:
         from aria_esi.commands.persona import cmd_validate_overlays
 
         # Create pilot structure
-        pilot_dir = tmp_path / "pilots" / "123_test"
+        pilot_dir = tmp_path / "userdata" / "pilots" / "123_test"
         pilot_dir.mkdir(parents=True)
 
         profile = pilot_dir / "profile.md"
@@ -503,7 +503,7 @@ persona_context:
         from aria_esi.commands.persona import cmd_validate_overlays
 
         # Create pilot with stale context
-        pilot_dir = tmp_path / "pilots" / "123_test"
+        pilot_dir = tmp_path / "userdata" / "pilots" / "123_test"
         pilot_dir.mkdir(parents=True)
 
         profile = pilot_dir / "profile.md"


### PR DESCRIPTION
## Summary

- Fix `persona-context --all` and `validate-overlays --all` constructing pilot registry paths without the `userdata/` prefix, causing lookups in the wrong directory

## Test plan

- [ ] `uv run aria-esi persona-context --all` finds and processes all registered pilots
- [ ] `uv run aria-esi validate-overlays --all` finds and validates all registered pilots
- [ ] Unit tests for both commands pass with corrected paths

Co-Authored-By: ARIA <LUM-VII-FAIC::SYS-CORE-23::0xE09A4>

*An elegant solution presents itself.*