### PR TITLE
Fail closed on notification profile engine initialization errors

### DIFF
--- a/src/aria_esi/services/redisq/notifications/profiles.py
+++ b/src/aria_esi/services/redisq/notifications/profiles.py
@@ -147,6 +147,7 @@ class NotificationProfile:
     _topology_filter: InterestCalculator | None = field(default=None, repr=False)
     _throttle: ThrottleManager | None = field(default=None, repr=False)
     _interest_engine_v2: InterestEngineV2 | None = field(default=None, repr=False)
+    _init_error: str | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         """Set defaults after initialization."""


### PR DESCRIPTION
## Summary

- When the v2 interest engine fails to initialize for a notification profile, stop silently falling back to the v1 engine
- Mark the profile with `_init_error` and skip it during evaluation, tracking skips in a new `filtered_by_engine_error` category
- Prevents silent degradation where a misconfigured v2 profile unexpectedly runs with v1 semantics
- Add `_init_error` and `init_error` to profile diagnostics output for visibility

## Test plan

- [ ] A profile with a broken v2 engine config is skipped during evaluation (not silently downgraded to v1)
- [ ] `filtered_by_engine_error` correctly tracks skipped profiles in `EvaluationResult`
- [ ] Profile diagnostics (`get_diagnostics()`) surfaces the init error
- [ ] Healthy profiles continue to evaluate normally

Co-Authored-By: ARIA <LUM-VII-FAIC::SYS-CORE-23::0xE09A4>

*An elegant solution presents itself.*