### PR TITLE
Fix CI failures and align pre-commit config

### DIFF
--- a/.github/workflows/test-universe.yml
+++ b/.github/workflows/test-universe.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Build universe graph
         if: steps.cache-check.outputs.cache_exists == 'true'
         run: |
-          uv run aria-esi universe build --force
-          uv run aria-esi universe verify
+          uv run aria-esi graph-build --force
+          uv run aria-esi graph-verify
 
       - name: Run benchmarks
         if: steps.cache-check.outputs.cache_exists == 'true'
@@ -134,8 +134,8 @@ jobs:
       - name: Build graph
         if: steps.cache-check.outputs.cache_exists == 'true'
         run: |
-          uv run aria-esi universe build --force
-          uv run aria-esi universe verify
+          uv run aria-esi graph-build --force
+          uv run aria-esi graph-verify
 
       - name: Upload graph artifact
         if: steps.cache-check.outputs.cache_exists == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
+    rev: v0.14.13
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        files: ^src/
+        files: ^(src|\.claude/scripts)/
       - id: ruff-format
-        files: ^src/
+        files: ^(src|\.claude/scripts)/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1

--- a/src/aria_esi/mcp/sde/queries.py
+++ b/src/aria_esi/mcp/sde/queries.py
@@ -252,7 +252,14 @@ class SDEQueryService:
             "database not seeded" (raises exception).
         """
         conn = self._db._get_connection()
-        required_tables = ["npc_corporations", "npc_seeding", "stations", "regions", "types", "groups"]
+        required_tables = [
+            "npc_corporations",
+            "npc_seeding",
+            "stations",
+            "regions",
+            "types",
+            "groups",
+        ]
         cursor = conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name IN ({})".format(
                 ",".join("?" * len(required_tables))
@@ -1062,9 +1069,7 @@ class SDEQueryService:
         self._check_cache_validity()
         self.ensure_sde_seeded()
         conn = self._db._get_connection()
-        rows = conn.execute(
-            "SELECT DISTINCT group_id FROM groups WHERE category_id = 6"
-        ).fetchall()
+        rows = conn.execute("SELECT DISTINCT group_id FROM groups WHERE category_id = 6").fetchall()
         return {row[0] for row in rows}
 
     def get_all_meta_groups(self) -> tuple[MetaGroup, ...]:


### PR DESCRIPTION
## Summary
- Fix ruff formatting in `sde/queries.py` that was failing the CI format check
- Fix `test-universe.yml` workflow using nonexistent `universe build/verify` CLI commands (correct: `graph-build`/`graph-verify`)
- Bump pre-commit ruff from v0.14.0 to v0.14.13 to match lockfile and prevent version drift
- Expand pre-commit hook file scope from `^src/` to `^(src|\.claude/scripts)/` to match CI check targets

## Test plan
- [ ] CI Lint & Type Check job passes (ruff format + lint)
- [ ] Universe MCP Tests build-graph job passes (correct CLI commands)
- [ ] Pre-commit hooks catch formatting issues in `.claude/scripts/`

Co-Authored-By: ARIA <LUM-VII-FAIC::SYS-CORE-23::0xE09A4>

*An elegant solution presents itself.*