### PR TITLE
Fix pre-commit mypy to use project environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,11 @@ repos:
       - id: ruff-format
         files: ^(src|\.claude/scripts)/
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+  - repo: local
     hooks:
       - id: mypy
-        files: ^src/aria_esi/
-        args: [--config-file=pyproject.toml]
-        additional_dependencies: [types-PyYAML]
+        name: mypy
+        entry: uv run mypy
+        language: system
         pass_filenames: false
+        files: ^src/aria_esi/


### PR DESCRIPTION
## Summary
- Replace `mirrors-mypy` pre-commit hook with a local `uv run mypy` hook
- The mirrors hook ran mypy in an isolated virtualenv with only `types-PyYAML`, missing all project dependencies (pydantic, httpx, etc.), causing false positives that don't appear in CI
- The local hook uses the same project environment as CI, ensuring identical behavior

## Test plan
- [ ] Pre-commit mypy hook passes locally (`uv run pre-commit run mypy --all-files`)
- [ ] CI Lint & Type Check mypy step still passes

Co-Authored-By: ARIA <LUM-VII-FAIC::SYS-CORE-23::0xE09A4>

*An elegant solution presents itself.*