### PR TITLE
Fix incorrect skill names and phantom ship group ID

### DIFF
--- a/.claude/scripts/aria-esi-sync.py
+++ b/.claude/scripts/aria-esi-sync.py
@@ -85,7 +85,6 @@ SHIP_GROUP_IDS = {
     1534,
     1538,
     1972,
-    2001,  # 2001 = Mining Frigate (Venture)
 }
 
 

--- a/reference/skills/breakpoint_skills.yaml
+++ b/reference/skills/breakpoint_skills.yaml
@@ -175,7 +175,7 @@ Remote Armor Repair Systems:
   category: "logi"
   reason: "T2 large remote reps significantly outperform T1/meta for fleet logistics"
 
-Remote Shield Emission:
+Shield Emission Systems:
   breakpoint_level: 5
   effect: "Required for Large Shield Transporter II"
   impact: "high"

--- a/reference/skills/ship_efficacy_rules.yaml
+++ b/reference/skills/ship_efficacy_rules.yaml
@@ -273,7 +273,7 @@ ship_roles:
         per_level: 5
         category: tank
         multiplicative: true
-      - skill: Armor Resistance Phasing
+      - skill: Resistance Phasing
         effect: "Allows Reactive Armor Hardener"
         per_level: 0
         category: utility
@@ -536,7 +536,7 @@ ship_roles:
         level: 5
         effect: "Required for Large Remote Armor Repairer II"
         reason: "T2 large remote reps significantly outperform T1/meta for fleet logistics"
-      - skill: Remote Shield Emission
+      - skill: Shield Emission Systems
         level: 5
         effect: "Required for Large Shield Transporter II"
         reason: "T2 large shield transfers significantly outperform T1/meta for fleet logistics"
@@ -550,7 +550,7 @@ ship_roles:
         per_level: 5
         category: support
         multiplicative: true
-      - skill: Remote Shield Emission
+      - skill: Shield Emission Systems
         effect: "+5% remote shield boost amount per level"
         per_level: 5
         category: support
@@ -568,7 +568,7 @@ ship_roles:
     easy_80_plan:
       required_5:
         - Remote Armor Repair Systems  # For armor logi
-        - Remote Shield Emission  # For shield logi
+        - Shield Emission Systems  # For shield logi
         - Capacitor Management  # BREAKPOINT: Cap stability threshold
       cap_at_4:
         - Capacitor Systems Operation

--- a/src/aria_esi/core/constants.py
+++ b/src/aria_esi/core/constants.py
@@ -68,7 +68,6 @@ _SHIP_GROUP_IDS_FALLBACK = {
     1534,  # Command Destroyer
     1538,  # Force Auxiliary
     1972,  # Flag Cruiser
-    2001,  # Mining Frigate (Venture!)
 }
 
 _ship_group_ids: set[int] | None = None

--- a/tests/mcp/test_sde_easy80.py
+++ b/tests/mcp/test_sde_easy80.py
@@ -465,7 +465,7 @@ class TestBreakpointSkillsConstants:
         """Logistics breakpoint skills are defined."""
         breakpoint_skills = load_breakpoint_skills()
         assert "Remote Armor Repair Systems" in breakpoint_skills
-        assert "Remote Shield Emission" in breakpoint_skills
+        assert "Shield Emission Systems" in breakpoint_skills
         assert "Capacitor Management" in breakpoint_skills
 
     def test_exploration_breakpoints_present(self):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -45,7 +45,6 @@ class TestShipGroupIDs:
         assert 27 in ids  # Battleship
         assert 420 in ids  # Destroyer
         assert 463 in ids  # Mining Barge
-        assert 2001 in ids  # Mining Frigate (Venture)
 
 
 class TestTradeHubConfiguration:


### PR DESCRIPTION
## Summary
- Rename "Remote Shield Emission" → "Shield Emission Systems" (SDE type_id 3422) in breakpoint_skills.yaml, ship_efficacy_rules.yaml, and tests
- Rename "Armor Resistance Phasing" → "Resistance Phasing" (SDE type_id 32797) in ship_efficacy_rules.yaml
- Remove nonexistent ship group 2001 from constants fallback and aria-esi-sync.py (Venture is group 25/Frigate, not a separate Mining Frigate group)

## Test plan
- [x] `tests/integration/test_skill_registry.py::TestYamlValidationGolden::test_breakpoint_skills_yaml_valid` passes
- [x] `tests/integration/test_skill_registry.py::TestYamlValidationGolden::test_efficacy_rules_yaml_valid` passes
- [x] `tests/test_constants.py::TestShipGroupIDs::test_common_ship_groups_present` passes
- [x] All 75 tests across affected test files pass

Co-Authored-By: ARIA <LUM-VII-FAIC::SYS-CORE-23::0xE09A4>

*An elegant solution presents itself.*