### PR TITLE
Fix corporation ticker in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ARIA is a Claude Code extension that turns Claude into a tactical EVE Online ass
    /   |  / __ \/  _/   |   Adaptive Reasoning & Intelligence Array
   / /| | / /_/ // // /| |   Tactical Advisory System
  / ___ |/ _, _// // ___ |
-/_/  |_/_/ |_/___/_/  |_|   by Luminaire Cognition [LUCOS]
+/_/  |_/_/ |_/___/_/  |_|   by Luminaire Cognition [LUCOG]
 ```
 
 <p><strong>Quick Docs:</strong>
@@ -438,4 +438,4 @@ See [ATTRIBUTION.md](ATTRIBUTION.md) for complete attribution details.
 
 ---
 
-*by Luminaire Cognition [LUCOS]*
+*by Luminaire Cognition [LUCOG]*


### PR DESCRIPTION
## Summary
- Corrects the corporation ticker from `[LUCOS]` to `[LUCOG]` in the README header and footer

## Test plan
- [x] Verify ticker displays correctly in ASCII banner and footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)